### PR TITLE
update filename in snakefile

### DIFF
--- a/snakefile
+++ b/snakefile
@@ -3,8 +3,7 @@ rule all:
     input:
         "out/grid_database.pkl",
         "out/vacc-vs-inf-group-1.png",
-        #"out/example-optimisation-result.png"
-	
+        "out/example-optimisation-result_a_0.5_b_0.1.png",
 
 
 rule make_grid_database_ode:
@@ -26,12 +25,8 @@ rule plot_example_optimisation_result:
         "ethics/optimisation.py",
         db = "out/grid_database.pkl",
         py = "plot-example-optimisation-result.py"
-    """
     output:
-        "out/example-optimisation-result.png",
-        "out/example-optimisation-result.svg"
-
-    """
+        "out/example-optimisation-result_a_0.5_b_0.1.png"
     shell:
         """
         python {input.py}


### PR DESCRIPTION
snakemake was bugging out because it didn't recognise the filenames for the output.
if you `rm -r out` and then run `snakemake -c1` it should all work fine now.

extra details: it would be better to read the *a* and *b* example values from the configuration file to construct the filenames at run time, but thye aren't there yet so i've hard coded them in the config.
